### PR TITLE
Fix sqlite error in Python 3.6

### DIFF
--- a/download-and-parse.py
+++ b/download-and-parse.py
@@ -15,7 +15,7 @@ def main():
     save_cards_to_database(cards)
 
 def download_card_json():
-    req = Request('https://api.hearthstonejson.com/v1/14830/enUS/cards.json', headers={'User-Agent' : "Magic Browser"}) 
+    req = Request('https://api.hearthstonejson.com/v1/20022/enUS/cards.json', headers={'User-Agent' : "Magic Browser"}) 
     response = urlopen(req)
     responseStr = response.read().decode('utf-8')
     return responseStr

--- a/download-and-parse.py
+++ b/download-and-parse.py
@@ -158,7 +158,7 @@ def save_cards_to_nested_csvs(cards):
                                     entourage_writer.writerow([card["id"], i])
 
 def save_cards_to_database(cards):
-    with sqlite3.connect('output/database.sqlite') as sql:
+    with sqlite3.connect('output/database.sqlite', isolation_level=None) as sql:
         sql.execute("""PRAGMA writable_schema = 1;""")
         sql.execute("""DELETE FROM sqlite_master WHERE type IN ('table', 'index', 'trigger')""")
         sql.execute("""PRAGMA writable_schema = 0;""")


### PR DESCRIPTION
There is an error in python 3.6

> sqlite3.OperationalError: cannot VACUUM from within a transaction


ref: https://bugs.python.org/issue29003